### PR TITLE
Add MicroBadger badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/stackfeed/docker-ubuntu.svg?branch=master)](https://travis-ci.org/stackfeed/docker-ubuntu) [![DockerHub](https://img.shields.io/badge/docker-available-blue.svg)](https://hub.docker.com/r/stackfeed/ubuntu) [![DockerHub](https://img.shields.io/docker/pulls/stackfeed/ubuntu.svg)](https://hub.docker.com/r/stackfeed/ubuntu)
+[![Build Status](https://travis-ci.org/stackfeed/docker-ubuntu.svg?branch=master)](https://travis-ci.org/stackfeed/docker-ubuntu) [![DockerHub](https://img.shields.io/badge/docker-available-blue.svg)](https://hub.docker.com/r/stackfeed/ubuntu) [![DockerHub](https://img.shields.io/docker/pulls/stackfeed/ubuntu.svg)](https://hub.docker.com/r/stackfeed/ubuntu) [![](https://images.microbadger.com/badges/image/stackfeed/ubuntu.svg)](https://microbadger.com/images/stackfeed/ubuntu "Get your own image badge on microbadger.com")
 
 # Ubuntu container with built-in init
 
@@ -11,3 +11,4 @@ These type of containers is meant to be used in code testing scenarios. For exam
 # Authors
 
 - Denis Baryshev (<dennybaa@gmail.com>)
+ 


### PR DESCRIPTION
We saw your image on Docker Hub at [stackfeed/ubuntu](https://hub.docker.com/r/stackfeed/ubuntu/), and we thought you might like this badge for your GitHub readme showing the image contents.

The badge shows the number of layers and download size of your Docker image, and links to our site where you can see the [contents of each layer](https://microbadger.com/images/stackfeed/ubuntu).

As you're using an automated build it will also show up in your Docker Hub description.

[![](https://images.microbadger.com/badges/image/stackfeed/ubuntu.svg)](https://microbadger.com/images/stackfeed/ubuntu "Get your own image badge on microbadger.com")
